### PR TITLE
Error al mostrar nombres de usuario en UTF-8

### DIFF
--- a/app/view/layout.php
+++ b/app/view/layout.php
@@ -36,7 +36,7 @@
 		</content>
 		<div class="right" id="menu">
 			<?php if ( auth::isLoggedIn() ) : ?>
-				<?= htmlentities(auth::getUser()->username) ?> <a href="<?= View::makeUri('/auth/logout') ?>">Logout</a><br />
+				<?= View::e(auth::getUser()->username) ?> <a href="<?= View::makeUri('/auth/logout') ?>">Logout</a><br />
 				<a href="<?= View::makeUri('/auth/changepassword') ?>">Change password</a>
 			<?php else : ?>
 			<form action="<?= View::makeUri('/auth/login') ?>" method="post">

--- a/app/view/score_get.php
+++ b/app/view/score_get.php
@@ -16,6 +16,6 @@
 <table>
 <?php foreach ( model_user::getLeaders(20) as $leader ) : ?>
 <?php $i ++ ?>
-<tr><td>#<?= $i ?></td><td><a href="<?= $leader->uri ?>"><?= htmlentities($leader->username) ?></a></td><td><?= $leader->score ?></td></tr>
+<tr><td>#<?= $i ?></td><td><a href="<?= $leader->uri ?>"><?= View::e($leader->username) ?></a></td><td><?= $leader->score ?></td></tr>
 <?php endforeach ?>
 </table>


### PR DESCRIPTION
En 2 layauts se usa la función htmlentities para escapar los nombres de los usuarios, pero no se les pasa el tercer parámetro de enconding por lo que no muestran correctamente nombres de usuario en utf-8.

En vez de pasar el patametro, reemplacé estas llamadas por las que veo que son el estándar del framework (View::e) que hace esto mismo.

Para probar si esto fallaba cree un usuario llamado äŕoüÜ~!שלום en esfriki.com, pido disculpas por esto.
